### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server
 - **Ad Blocking**: Optional ad blocking during scraping
 - **Custom Actions**: Support for custom scraping actions
 
+<a href="https://glama.ai/mcp/servers/th4nzh22ea"><img width="380" height="200" src="https://glama.ai/mcp/servers/th4nzh22ea/badge" alt="Server Firecrawl MCP server" /></a>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Firecrawl](https://glama.ai/mcp/servers/th4nzh22ea) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/th4nzh22ea"><img width="380" height="200" src="https://glama.ai/mcp/servers/th4nzh22ea/badge" alt="Server Firecrawl MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.